### PR TITLE
ENH: SelectModulePopUp defaultInput parameter is used

### DIFF
--- a/PipelineCreator/Widgets/SelectModulePopUp.py
+++ b/PipelineCreator/Widgets/SelectModulePopUp.py
@@ -22,7 +22,8 @@ class SelectModulePopUp(qt.QDialog):
 
     #input type
     self.cboxInputType = qt.QComboBox()
-    self.cboxInputType.addItems(sorted(list(set([x.GetInputType() for x in self._availableModules]))))
+    items = sorted(list(set([x.GetInputType() for x in self._availableModules])))
+    self.cboxInputType.addItems(items)
     self.cboxInputType.currentTextChanged.connect(self._updateListWidget)
     self.formLayout.addRow("Input Type:", self.cboxInputType)
 
@@ -58,6 +59,11 @@ class SelectModulePopUp(qt.QDialog):
     self.masterLayout.addItem(verticalSpacer)
 
     #ui is ready. initialize state
+    if defaultInput is not None:
+      try:
+        self.cboxInputType.setCurrentIndex(items.index(defaultInput))
+      except ValueError:
+        pass
     self._updateListWidget()
 
   def _updateListWidget(self):


### PR DESCRIPTION
Previously defaultInput was in the constructor signature, but was not
used. Now it can be used to set the default for the pop up.

The pipeline creator uses this to set the default to the output type of the last module in the pipeline during "Insert Module"