### PR TITLE
BUG: Fix case iterator on newer Slicer versions

### DIFF
--- a/PipelineCaseIterator/PipelineCaseIterator.py
+++ b/PipelineCaseIterator/PipelineCaseIterator.py
@@ -381,7 +381,6 @@ class PipelineCaseIteratorLogic(ScriptedLoadableModuleLogic):
 
     cmd = [
       launcherPath,
-      '--no-main-window',
       '--python-script',
       scriptPath,
       '--',


### PR DESCRIPTION
The --no-main-window flag is being defacto deprecated. Change to not
use this flag anymore.
This means that a pop up window will appear during the case iterator.

Per https://github.com/Slicer/Slicer/issues/6181, the `--no-main-window` flag is no longer really being supported. This PR allows the case iterator to run on newer Slicer versions by not using that flag.