### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(Pipelines)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/KitwareMedical/SlicerPipelines/blob/main/README.md")
 set(EXTENSION_CATEGORY "Pipelines")
-set(EXTENSION_CONTRIBUTORS "Connor Bowley (Kitware, Inc.), Harald Scheirich (Kitware Inc.), David Allemang (Kitware Inc.)")
+set(EXTENSION_CONTRIBUTORS "Connor Bowley (Kitware, Inc.), Sam Horvath (Kitware, Inc.), Harald Scheirich (Kitware Inc.), David Allemang (Kitware Inc.)")
 set(EXTENSION_DESCRIPTION "SlicerPipelines is an extension for 3D Slicer that offers the ability to create simple modules (aka pipelines) via a GUI interface with no coding knowledge needed")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/KitwareMedical/SlicerPipelines/main/Pipelines.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/KitwareMedical/SlicerPipelines/main/Screenshots/1.png https://raw.githubusercontent.com/KitwareMedical/SlicerPipelines/main/Screenshots/2.png https://raw.githubusercontent.com/KitwareMedical/SlicerPipelines/main/Screenshots/3.png")


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.